### PR TITLE
Handle Maven SNAPSHOT versions in Nexus 3

### DIFF
--- a/libs/nexus-v3/nexus.ts
+++ b/libs/nexus-v3/nexus.ts
@@ -49,13 +49,21 @@ export class nexus {
       hostUri.searchParams.set('maven.classifier', classifier);
     }
     // switch to the "version" criteria, should work in the case of release and snapshot versions
-    // hostUri.searchParams.append("maven.baseVersion", baseVersion);
-    hostUri.searchParams.append('version', version);
+    hostUri.searchParams.append('maven.baseVersion', version);
+    // hostUri.searchParams.append('version', version);
+
+    if (this.isSnapshot(version)) {
+      hostUri.searchParams.set('sort', 'version');
+    }
 
     console.log(`Download asset using '${hostUri}'.`);
     // Execute the request
     await this.executeRequest(hostUri, auth, acceptUntrustedCerts);
     console.log(`Completed download asset using '${hostUri}'.`);
+  }
+
+  private isSnapshot(version: string): boolean {
+    return /-SNAPSHOT$/.test(version);
   }
 
   private async executeRequest(


### PR DESCRIPTION
This makes it handle maven snapshot versions.
---

I'll be doing some more work on this task. I plan to make it handle more than just maven, for example.
I think I'll add some unit tests too.

There's a chance I will publish the forked version to the marketplace, unless I decide to keep it private for my organisation only.

Either way, if you want some of the changes, I can probably open a few PRs as I go.